### PR TITLE
Move NaturalLanguageQueryOptions out of DatabaseGptClient

### DIFF
--- a/src/DatabaseGpt/DatabaseGptClient.cs
+++ b/src/DatabaseGpt/DatabaseGptClient.cs
@@ -148,12 +148,3 @@ internal class DatabaseGptClient : IDatabaseGptClient
         return result;
     }
 }
-
-public class NaturalLanguageQueryOptions
-{
-    public Func<IServiceProvider, ValueTask>? OnStarting { get; set; }
-
-    public Func<IEnumerable<string>, IServiceProvider, ValueTask>? OnCandidateTablesFound { get; set; }
-
-    public Func<string, IServiceProvider, ValueTask>? OnQueryGenerated { get; set; }
-}

--- a/src/DatabaseGpt/NaturalLanguageQueryOptions.cs
+++ b/src/DatabaseGpt/NaturalLanguageQueryOptions.cs
@@ -1,0 +1,10 @@
+namespace DatabaseGpt;
+
+public class NaturalLanguageQueryOptions
+{
+    public Func<IServiceProvider, ValueTask>? OnStarting { get; set; }
+
+    public Func<IEnumerable<string>, IServiceProvider, ValueTask>? OnCandidateTablesFound { get; set; }
+
+    public Func<string, IServiceProvider, ValueTask>? OnQueryGenerated { get; set; }
+}


### PR DESCRIPTION
Hello!
I noticed that src/DatabaseGpt/DatabaseGptClient.cs contains more than one classes, which is not big deal, but personally I prefer to keep rule 'one class per file' in all cases.
So I move NaturalLanguageQueryOptions into separated file to improve code readability and organization.
I hope this change aligns with your coding standards.
Looking forward to your feedback!