### PR TITLE
DatabaseGptClient is now disposable

### DIFF
--- a/src/DatabaseGpt.Abstractions/IDatabaseGptProvider.cs
+++ b/src/DatabaseGpt.Abstractions/IDatabaseGptProvider.cs
@@ -2,7 +2,7 @@
 
 namespace DatabaseGpt.Abstractions;
 
-public interface IDatabaseGptProvider
+public interface IDatabaseGptProvider : IDisposable
 {
     string Name { get; }
 

--- a/src/DatabaseGpt/DatabaseGptClient.cs
+++ b/src/DatabaseGpt/DatabaseGptClient.cs
@@ -9,13 +9,14 @@ using Polly.Registry;
 
 namespace DatabaseGpt;
 
-internal class DatabaseGptClient : IDatabaseGptClient
+internal class DatabaseGptClient : IDatabaseGptClient, IDisposable
 {
     private readonly IChatGptClient chatGptClient;
     private readonly IDatabaseGptProvider provider;
     private readonly IServiceProvider serviceProvider;
     private readonly ResiliencePipeline pipeline;
     private readonly DatabaseGptSettings databaseGptSettings;
+    private bool disposedValue;
 
     public DatabaseGptClient(IChatGptClient chatGptClient, ResiliencePipelineProvider<string> pipelineProvider, IServiceProvider serviceProvider, DatabaseGptSettings databaseGptSettings)
     {
@@ -112,5 +113,24 @@ internal class DatabaseGptClient : IDatabaseGptClient
         }, cancellationToken);
 
         return reader;
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!disposedValue)
+        {
+            if (disposing)
+            {
+                provider.Dispose();
+            }
+
+            disposedValue = true;
+        }
+    }
+
+    public void Dispose()
+    {
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
     }
 }


### PR DESCRIPTION
Added IDisposable interface implementation to DatabaseGptClient in order to properly dispose also the internal provider.
This implementation should solve the issue #22