### PR TITLE
Update package references across multiple projects

### DIFF
--- a/samples/DatabaseGpt.Web/DatabaseGpt.Web.csproj
+++ b/samples/DatabaseGpt.Web/DatabaseGpt.Web.csproj
@@ -8,14 +8,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="LigerShark.WebOptimizer.Core" Version="3.0.405" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.6" />
-        <PackageReference Include="MinimalHelpers.OpenApi" Version="2.0.8" />
-        <PackageReference Include="MinimalHelpers.Routing.Analyzers" Version="1.0.7" />
-        <PackageReference Include="OperationResultTools.AspNetCore.Http" Version="1.0.22" />
+        <PackageReference Include="LigerShark.WebOptimizer.Core" Version="3.0.413" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7" />
+        <PackageReference Include="MinimalHelpers.OpenApi" Version="2.0.9" />
+        <PackageReference Include="MinimalHelpers.Routing.Analyzers" Version="1.0.8" />
+        <PackageReference Include="OperationResultTools.AspNetCore.Http" Version="1.0.24" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
-        <PackageReference Include="TinyHelpers" Version="3.1.5" />
-        <PackageReference Include="TinyHelpers.AspNetCore" Version="3.1.4" />
+        <PackageReference Include="TinyHelpers" Version="3.1.10" />
+        <PackageReference Include="TinyHelpers.AspNetCore" Version="3.1.6" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/DatabaseGpt.Sqlite/DatabaseGpt.Sqlite.csproj
+++ b/src/DatabaseGpt.Sqlite/DatabaseGpt.Sqlite.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.1.35" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.6" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DatabaseGpt/DatabaseGpt.csproj
+++ b/src/DatabaseGpt/DatabaseGpt.csproj
@@ -11,9 +11,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="ChatGptNet" Version="3.2.15" />
-        <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.5.0" />
-        <PackageReference Include="Polly.Extensions" Version="8.4.0" />
+        <PackageReference Include="ChatGptNet" Version="3.2.18" />
+        <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.7.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Updated `DatabaseGpt.Web.csproj` with newer versions of:
- `LigerShark.WebOptimizer.Core` from `3.0.405` to `3.0.413`
- `Microsoft.AspNetCore.OpenApi` from `8.0.6` to `8.0.7`
- `MinimalHelpers.OpenApi` from `2.0.8` to `2.0.9`
- `MinimalHelpers.Routing.Analyzers` from `1.0.7` to `1.0.8`
- `OperationResultTools.AspNetCore.Http` from `1.0.22` to `1.0.24`
- `TinyHelpers` from `3.1.5` to `3.1.10`
- `TinyHelpers.AspNetCore` from `3.1.4` to `3.1.6`

Updated `DatabaseGpt.Sqlite.csproj` with:
- `Microsoft.Data.Sqlite` from `8.0.6` to `8.0.7`

Updated `DatabaseGpt.csproj` with:
- `ChatGptNet` from `3.2.15` to `3.2.18`
- `Microsoft.Extensions.Http.Resilience` from `8.5.0` to `8.7.0`
- Removed `Polly.Extensions` package reference.